### PR TITLE
No longer include six in tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ deps =
     coverage
     hypothesis
     pytest>=2.8
-    six
 commands =
     coverage --version
     coverage run --timid --branch -m pytest tests/
@@ -17,7 +16,6 @@ deps =
     hypothesis
     pylint
     pytest>=2.8
-    six
 commands =
     ./check.py src/justbases
     ./check.py tests
@@ -26,6 +24,5 @@ commands =
 deps =
     hypothesis
     pytest>=2.8
-    six
 commands =
     py.test tests -rsx


### PR DESCRIPTION
It is required by setup.

Signed-off-by: mulhern <amulhern@redhat.com>