### PR TITLE
Change positive attribute to sign attribute.

### DIFF
--- a/src/justbases/_display.py
+++ b/src/justbases/_display.py
@@ -124,7 +124,7 @@ class Number(object):
     ])
 
     @classmethod
-    def xform(cls, left, right, repeating, config, base, positive):
+    def xform(cls, left, right, repeating, config, base, sign):
         """
         Return prefixes for tuple.
 
@@ -133,7 +133,7 @@ class Number(object):
         :param str repeating: repeating part
         :param DisplayConfig config: display configuration
         :param int base: the base in which value is displayed
-        :param bool positive: whether value is non-negative
+        :param int sign: -1, 0, 1 as appropriate
         :returns: the number string
         :rtype: str
         """
@@ -148,10 +148,8 @@ class Number(object):
             else:
                 base_str = ''
 
-        sign = '' if positive else '-'
-
         result = {
-           'sign' : sign,
+           'sign' : '-' if sign == -1 else '',
            'base_str' : base_str,
            'left' : left,
            'radix' : '.' if right else "",
@@ -250,7 +248,7 @@ class String(object):
            repeating_str,
            display,
            radix.base,
-           radix.positive
+           radix.sign
         )
 
         decorators = Decorators.decorators(display, relation)

--- a/tests/display_test.py
+++ b/tests/display_test.py
@@ -117,7 +117,7 @@ class TestNumber(unittest.TestCase):
           strip_config=strategies.just(StripConfig())
        ),
        strategies.integers(min_value=2, max_value=16),
-       strategies.booleans()
+       strategies.integers(min_value=-1, max_value=1)
     )
     @settings(max_examples=100)
     def testXform(
@@ -127,7 +127,7 @@ class TestNumber(unittest.TestCase):
        repeating_part,
        config,
        base,
-       positive
+       sign
     ):
         """
         Test xform.
@@ -140,11 +140,11 @@ class TestNumber(unittest.TestCase):
            repeating_part,
            config,
            base,
-           positive
+           sign
         )
-        if config.show_base and base == 16 and positive:
+        if config.show_base and base == 16 and sign != -1:
             self.assertTrue(result.startswith('0x'))
-        if config.show_base and base == 8 and positive:
+        if config.show_base and base == 8 and sign != -1:
             self.assertTrue(result.startswith('0'))
 
 

--- a/tests/test_rationals.py
+++ b/tests/test_rationals.py
@@ -44,7 +44,7 @@ class RationalsTestCase(unittest.TestCase):
         Test that functions are inverses of each other.
         """
         (result, relation) = Radices.from_rational(value, to_base)
-        assert result.positive or value < 0
+        assert result.sign in (0, 1) or value < 0
         assert relation == 0
         assert result.as_rational() == value
 


### PR DESCRIPTION
non-negative would have been a better choice for the name any way, if it
remained a bool.

Also, three numbers, -1 for negative, 1 for positive, and 0 for neither can
be used more directly in computation.