### PR TITLE
Remove license classifer deprecated by PEP 639

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ platforms =
 classifiers =
   Development Status :: 4 - Beta
   Intended Audience :: Developers
-  License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
   Operating System :: POSIX :: Linux
   Programming Language :: Python
   Programming Language :: Python :: 3


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/774